### PR TITLE
Aparece barra de desplazamiento horizontal

### DIFF
--- a/components/section.js
+++ b/components/section.js
@@ -17,6 +17,7 @@ const styles = css`
     display: flex;
     flex-direction: column;
     position: relative;
+    overflow: hidden;
   }
 
   .diagonal-bar {


### PR DESCRIPTION
**Sección** -> [https://delacruz.dev/mentoring](https://delacruz.dev/mentoring)

El svg dentro del elemento "diagonal-bar" provoca que aparezca una barra de desplazamiento en el componente "mentoring-benefits". Creo que añadiendo el `overflow: hidden;` al section se solucionaría el problema.

![Captura de pantalla 2020-09-08 a las 14 36 12](https://user-images.githubusercontent.com/8589135/92480595-67d46900-f1e5-11ea-896f-b5b55a412624.png)

Espero que sea de ayuda.

Saludos,
Luis