### PR TITLE
Faltó agregar la palabra 'no' para que se entienda bien lo que hace la función.

### DIFF
--- a/posts/memoize-en-javascript.md
+++ b/posts/memoize-en-javascript.md
@@ -45,7 +45,7 @@ function getProductById(id) {
    * Obtiene un producto de una API por su id.
    * La API es lentilla 🐢.
    * Una vez tengamos el producto, podemos 
-   * recordarlo para tener que volver a pedírselo a la API.
+   * recordarlo para no tener que volver a pedírselo a la API.
    */
 }
 ```


### PR DESCRIPTION
Solo agregar la palabra 'no' a la oración 'Una vez tengamos el producto, podemos recordarlo para no tener que volver a pedírselo a la API' .